### PR TITLE
Remove Multidex usages

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -131,8 +131,6 @@ dependencies {
     testImplementation(AppDependencies.kotlinCoRoutinesCoreTest)
     testImplementation(AppDependencies.junit)
     testImplementation(AppDependencies.robolectric)
-    testImplementation(AppDependencies.robolectricShadows)
-    testImplementation(AppDependencies.robolectricSupport)
     testImplementation(AppDependencies.archCoreTesting)
     testImplementation(AppDependencies.junitRunner)
     testImplementation(AppDependencies.mockito)

--- a/buildSrc/src/main/kotlin/AppDependencies.kt
+++ b/buildSrc/src/main/kotlin/AppDependencies.kt
@@ -12,7 +12,6 @@ object AppDependencies {
     const val fragmentKTX = "androidx.fragment:fragment-ktx:${Versions.fragmentKTX}"
     const val material = "com.google.android.material:material:${Versions.material}"
     const val coreKtx = "androidx.core:core-ktx:${Versions.coreKTX}"
-    const val legacySupport = "androidx.legacy:legacy-support-v4:${Versions.support}"
     const val gson = "com.google.code.gson:gson:${Versions.gson}"
 
     // Lifecycle frameworks
@@ -78,9 +77,6 @@ object AppDependencies {
     // Robolectric and Espresso framework
     const val mockk = "io.mockk:mockk:${Versions.mockk}"
     const val robolectric = "org.robolectric:robolectric:${Versions.robolectric}"
-    const val robolectricShadows = "org.robolectric:shadows-multidex:${Versions.robolectricShadows}"
-    const val robolectricSupport =
-        "org.robolectric:shadows-supportv4:${Versions.robolectricShadows}"
     const val espressoIdling =
         "androidx.test.espresso:espresso-idling-resource:${Versions.espresso}"
     const val espressoContrib = "androidx.test.espresso:espresso-contrib:${Versions.espresso}"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -23,7 +23,6 @@ object Versions {
     const val archLifeCycleExt = "2.2.0"
     const val gson = "2.8.6"
     const val retrofit = "2.9.0"
-    const val support = "1.0.0"
     const val dagger = "2.49"
     const val okHttp3 = "4.4.0"
     const val picasso = "2.71828"
@@ -40,7 +39,6 @@ object Versions {
     const val mockk = "1.13.8"
 
     const val robolectric = "4.5"
-    const val robolectricShadows = "4.5"
     const val kotlinCoroutineTest = "1.4.2"
     const val nhaarmanMockito = "2.2.0"
     const val okHttpMockServer = "4.7.2"


### PR DESCRIPTION
Since the min SDK is 33, it is no longer necessary to use the Multidex library.

See the following for more info: https://developer.android.com/build/multidex#mdex-on-l